### PR TITLE
docs: fix typo in schema

### DIFF
--- a/src/main/java/io/kestra/plugin/ldap/Search.java
+++ b/src/main/java/io/kestra/plugin/ldap/Search.java
@@ -51,7 +51,7 @@ import org.slf4j.Logger;
         @io.kestra.core.models.annotations.Example(
             title = """
                     Retrieve LDAP entries.
-                    In this exemple, assuming that their is exactly one entry matching each of our filter,
+                    In this example, assuming that their is exactly one entry matching each of our filter,
                     the outputs of the task would be four entries in this order (since we search two times in the same baseDn) :
                     (dn, description, mail) of {melusine, metatron, melusine, metatron}.""",
             code = {


### PR DESCRIPTION
### What changes are being made and why?

Correcting the typos in the schema to satisfy the codespell check used in SchemaStore, see [https://github.com/kestra-io/kestra/issues/4653](https://github.com/kestra-io/kestra/issues/4653) for further details