### PR TITLE
feat(encrypted_fields_handling): add support for handling base64-encypted LDIF fields

### DIFF
--- a/src/test/java/io/kestra/plugin/ldap/IonToLdifTest.java
+++ b/src/test/java/io/kestra/plugin/ldap/IonToLdifTest.java
@@ -28,7 +28,7 @@ public class IonToLdifTest {
         // specific test values :
         inputs.add("""
             {dn:"cn=bob@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 1","Melusine lover"],someOtherAttribute:["perhaps","perhapsAgain"]}}
-            {dn:"cn=tony@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 2","Melusine lover as well"],someOtherAttribute:["perhaps 2","perhapsAgain 2"]}}""");// fst file
+            {dn:"cn=tony@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 2","Melusine lover as well"],someOtherAttribute:["perhaps 2",base64::"TGlzdGUgZCfDVVQ=","perhapsAgain 2"]}}""");// fst file
         inputs.add("""
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 3"],someOtherAttribute:["Melusine lover, obviously"]}}
             {dn:"cn=yennefer@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 2"],someOtherAttribute:["Loves herself"]}}""");// scnd file
@@ -37,7 +37,7 @@ public class IonToLdifTest {
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"moddn",newDn:{newrdn:"cn=triss@orga.com",deleteoldrdn:false,newsuperior:"ou=expeople,dc=example,dc=com"}}
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"moddn",newDn:{newrdn:"cn=triss@orga.com",deleteoldrdn:true,newsuperior:"ou=expeople,dc=example,dc=com"}}
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"moddn",newDn:{newrdn:"cn=triss@orga.com",deleteoldrdn:true}}
-            {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"add",attributes:{description:["Some description 3"],someOtherAttribute:["Melusine lover, obviously"]}}""");// third file, includes changeType
+            {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"add",attributes:{description:[base64::"TGlzdGUgZCfDVVQ="],someOtherAttribute:["Melusine lover, obviously"]}}""");// third file, includes changeType
         expectations.add("""
             dn: cn=bob@orga.com,ou=diffusion_list,dc=orga,dc=com
             description: Some description 1
@@ -49,6 +49,7 @@ public class IonToLdifTest {
             description: Some description 2
             description: Melusine lover as well
             someOtherAttribute: perhaps 2
+            someOtherAttribute:: TGlzdGUgZCfDVVQ=
             someOtherAttribute: perhapsAgain 2
 
             """);// fst file
@@ -100,7 +101,7 @@ public class IonToLdifTest {
 
             dn: cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com
             changetype: add
-            description: Some description 3
+            description:: TGlzdGUgZCfDVVQ=
             someOtherAttribute: Melusine lover, obviously
 
             """);// third file

--- a/src/test/java/io/kestra/plugin/ldap/LdifToIonTest.java
+++ b/src/test/java/io/kestra/plugin/ldap/LdifToIonTest.java
@@ -35,9 +35,10 @@ public class LdifToIonTest {
 
             dn: cn=tony@orga.com,ou=diffusion_list,dc=orga,dc=com
             description: Some description 2
+            description:: TGlzdGUgZCfDg8KpY2hhbmdlIHN1ciBsZSBzdWl2aSBkZSBsYSBtYXNzZSBzYWxhcmlhbGUgZGUgbCdJVVQ=
             description: Melusine lover as well
             someOtherAttribute: perhaps 2
-            someOtherAttribute: perhapsAgain 2""");// fst file
+            someOtherAttribute: perhapsAgain 2""");// fst file with encrypted value
         inputs.add("""
             dn: cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com
             description: Some description 3
@@ -53,7 +54,7 @@ public class LdifToIonTest {
             description: Some description 3
             -
             add: description
-            description: Some description 4
+            description:: TGlzdGUgZCfDg8KpY2hhbmdlIHN1ciBsZSBzdWl2aSBkZSBsYSBtYXNzZSBzYWxhcmlhbGUgZGUgbCdJVVQ=
             -
             replace: someOtherAttribute
             someOtherAttribute: Loves herself more
@@ -89,12 +90,12 @@ public class LdifToIonTest {
             """);// third file, includes changeType
         expectations.add("""
             {dn:"cn=bob@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 1","Melusine lover"],someOtherAttribute:["perhaps","perhapsAgain"]}}
-            {dn:"cn=tony@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 2","Melusine lover as well"],someOtherAttribute:["perhaps 2","perhapsAgain 2"]}}""");// fst file
+            {dn:"cn=tony@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 2",base64::"TGlzdGUgZCfDg8KpY2hhbmdlIHN1ciBsZSBzdWl2aSBkZSBsYSBtYXNzZSBzYWxhcmlhbGUgZGUgbCdJVVQ=","Melusine lover as well"],someOtherAttribute:["perhaps 2","perhapsAgain 2"]}}""");// fst file
         expectations.add("""
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 3"],someOtherAttribute:["Melusine lover, obviously"]}}
             {dn:"cn=yennefer@orga.com,ou=diffusion_list,dc=orga,dc=com",attributes:{description:["Some description 2"],someOtherAttribute:["Loves herself"]}}""");// scnd file
         expectations.add("""
-            {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"modify",modifications:[{operation:"DELETE",attribute:"description",values:["Some description 3"]},{operation:"ADD",attribute:"description",values:["Some description 4"]},{operation:"REPLACE",attribute:"someOtherAttribute",values:["Loves herself more"]},{operation:"INCREMENT",attribute:"uidNumber",values:["-4"]}]}
+            {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"modify",modifications:[{operation:"DELETE",attribute:"description",values:["Some description 3"]},{operation:"ADD",attribute:"description",values:[base64::"TGlzdGUgZCfDg8KpY2hhbmdlIHN1ciBsZSBzdWl2aSBkZSBsYSBtYXNzZSBzYWxhcmlhbGUgZGUgbCdJVVQ="]},{operation:"REPLACE",attribute:"someOtherAttribute",values:["Loves herself more"]},{operation:"INCREMENT",attribute:"uidNumber",values:["-4"]}]}
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"delete"}
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"moddn",newDn:{newrdn:"cn=triss@orga.com",deleteoldrdn:false,newsuperior:"ou=expeople,dc=example,dc=com"}}
             {dn:"cn=triss@orga.com,ou=diffusion_list,dc=orga,dc=com",changeType:"moddn",newDn:{newrdn:"cn=triss@orga.com",deleteoldrdn:true,newsuperior:"ou=expeople,dc=example,dc=com"}}


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made
Add support for handling base64-encypted LDIF fields non-invasively while transforming LDIF files to ION ones and reversely, enabling interaction with LDIF servers that use various field encodings.

Nothing changes besides that, doc has been change accordingly.

### And why?

In ldif files, attributes values of entries that start with a semicolon ':' -> `description:: TGlzdGUgZCfDVVQ=` -> are supposed to indicate that the field is base64 encoded.

#### Quick explanation of previous behaviour of the transformations :

While writing in ION format the ldap.sdk lib was automaticaly translating such encoded fields even since sometimes it produced non-UTF8 compatible text such as accents (' ì ').

#### Quick explanation of the fixed behaviour :

Encoded fields are no more decoded, ION entries that contain base64 encoded fields are now specified with a Type Annotation  "base64::". 

I.E. 

LDIF entry: 
`description: Some description`
`description:: TGlzdGUgZCfDVVQ=`
`description: Some other description`

Becomes as ION :
`attributes:{description:["Some description",base64::"TGlzdGUgZCfDVVQ=","Some other description"]`