### PR TITLE
Feat/gssapi authentication method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,11 @@ maven.pom {
             name = "Carcenac Sautron Izaac"
             organization = "IUT TLSE3"
         }
+        developer {
+            id = "befe"
+            name = "Benjamin Féron"
+            organization = "IUT TLSE3"
+        }
     }
 }
 

--- a/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
+++ b/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 public abstract class LdapConnection extends Task {
     @Schema(
         title = "Hostname",
-        description = "Hostname for connection.x"
+        description = "Hostname for connection."
     )
     @PluginProperty(dynamic = true)
     @NotNull

--- a/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
+++ b/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
@@ -1,7 +1,11 @@
 package io.kestra.plugin.ldap;
 
+import com.unboundid.ldap.sdk.BindRequest;
+import com.unboundid.ldap.sdk.GSSAPIBindRequest;
+import com.unboundid.ldap.sdk.GSSAPIBindRequestProperties;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.SimpleBindRequest;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -11,9 +15,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotNull;
 
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import org.slf4j.Logger;
 
 @SuperBuilder
 @Getter
@@ -21,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class LdapConnection extends Task {
     @Schema(
         title = "Hostname",
-        description = "Hostname for connection."
+        description = "Hostname for connection.x"
     )
     @PluginProperty(dynamic = true)
     @NotNull
@@ -36,8 +43,8 @@ public abstract class LdapConnection extends Task {
     protected String port;
 
     @Schema(
-        title = "User DN",
-        description = "User DN for connection."
+        title = "User",
+        description = "Username for connection."
     )
     @PluginProperty(dynamic = true)
     @NotNull
@@ -51,17 +58,91 @@ public abstract class LdapConnection extends Task {
     @NotNull
     protected String password;
 
+    @Schema(
+        title = "Authentication method",
+        description = "Authentication method to use with LDAP server.",
+        allowableValues = {"simple", "gssapi"}
+    )
+    @PluginProperty(dynamic = true)
+    @NotNull
+    @Default
+    protected String authMethod = "simple";
+
+    @Schema(
+        title = "Kerberos key distribution center",
+        description = """
+            Needed for GSSAPI authentication method.
+            If set, property realm must be set too.
+            If this is not provided, an attempt will be made to determine the appropriate value from the system configuration."""
+    )
+    @PluginProperty(dynamic = true)
+    protected String kdc;
+
+    @Schema(
+        title = "Realm",
+        description = """
+            Needed for GSSAPI authentication method.
+            If set, property kdc must be set too.
+            If this is not provided, an attempt will be made to determine the appropriate value from the system configuration."""
+    )
+    @PluginProperty(dynamic = true)
+    protected String realm;
+
     /**
      * Opens a connection with user provided informations.
      * @param runContext : A context that may evaluate pebble expressions regarding the connection informations.
      * @return A new LDAPConnection to perform action with the LDAP server.
      */
-    protected LDAPConnection getLdapConnection(RunContext runContext) throws LDAPException, IllegalVariableEvaluationException {
-        return new LDAPConnection(
-            runContext.render(hostname),
-            Integer.parseInt(runContext.render(port)),
-            runContext.render(userDn),
-            runContext.render(password)
+    protected LDAPConnection getLdapConnection(RunContext runContext) throws Exception, LDAPException, IllegalVariableEvaluationException {
+        Logger logger = runContext.logger();
+        String authMethodProperty = runContext.render(authMethod);
+        try {
+            LDAPConnection connection = new LDAPConnection(
+                runContext.render(hostname),
+                Integer.parseInt(runContext.render(port))
             );
+            BindRequest bindRequest;
+
+            switch (authMethodProperty) {
+                case "simple":
+                    bindRequest = new SimpleBindRequest(
+                        runContext.render(userDn),
+                        runContext.render(password)
+                    );
+                    break;
+                case "gssapi":
+                    String kdcProperty = runContext.render(kdc);
+                    String realmProperty = runContext.render(realm);
+
+                    GSSAPIBindRequestProperties gssapiProperties = new GSSAPIBindRequestProperties(
+                        runContext.render(userDn),
+                        runContext.render(password)
+                    );
+
+                    if (
+                        (kdcProperty == null && realmProperty != null) ||
+                        (kdcProperty != null && realmProperty == null)
+                    ) {
+                        throw new Exception("Property kdc and realm both must be set or neither must be set.");
+                    }
+
+                    if (kdcProperty != null) {
+                        gssapiProperties.setKDCAddress(kdcProperty);
+                    }
+                    if (realmProperty != null) {
+                        gssapiProperties.setRealm(realmProperty);
+                    }
+
+                    bindRequest = new GSSAPIBindRequest(gssapiProperties);
+                    break;
+                default:
+                    throw new Exception(String.format("Invalid authentication method \"%s\".", authMethodProperty));
+            }
+            connection.bind(bindRequest);
+            return connection;
+        } catch (LDAPException e) {
+            logger.error("LDAP connextion error: {}", e.getResultString());
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
There is now 2 authentication methods : simple and GSS-API. Default method is simple.

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

Some LDAP servers require Kerberos authentication.
This pull request adds Kerberos support via the GSS-API standard.

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

Tested on a Microsoft AD LDS (Active Directory Lightweight Directory Services) with success.

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->
