### PR TITLE
Input "hostname" can be declared with pebble

### DIFF
--- a/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
+++ b/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
@@ -113,7 +113,7 @@ public abstract class LdapConnection extends Task {
         final boolean trustAllCertificates = sslOptions != null && runContext.render(sslOptions.getInsecureTrustAllCertificates()).as(Boolean.class).orElse(false);
 
         try {
-            LDAPConnection connection = createLdapConnection(hostname, Integer.parseInt(runContext.render(port)), trustAllCertificates);
+            LDAPConnection connection = createLdapConnection(runContext.render(hostname), Integer.parseInt(runContext.render(port)), trustAllCertificates);
             BindRequest bindRequest;
 
             switch (authMethodProperty) {

--- a/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
+++ b/src/main/java/io/kestra/plugin/ldap/LdapConnection.java
@@ -113,7 +113,11 @@ public abstract class LdapConnection extends Task {
         final boolean trustAllCertificates = sslOptions != null && runContext.render(sslOptions.getInsecureTrustAllCertificates()).as(Boolean.class).orElse(false);
 
         try {
-            LDAPConnection connection = createLdapConnection(runContext.render(hostname), Integer.parseInt(runContext.render(port)), trustAllCertificates);
+            LDAPConnection connection = createLdapConnection(
+                runContext.render(hostname),
+                Integer.parseInt(runContext.render(port)),
+                trustAllCertificates
+            );
             BindRequest bindRequest;
 
             switch (authMethodProperty) {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
Before this bugfix, it was not possible to use Pebble to set the "hostname" input. This is now fixed.
---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

```yaml
id: ldap_with_hostname_as_pebble
namespace: test

variables:
  hostname: "ldap.domain.ltd"
  port: "389"
  user_dn: "cn=kestra,ou=services_accounts,dc=domain,dc=ltd"
  password: "my secret password"
  base_dn: "ou=people,dc=domain,dc=ltd"

tasks:

  - id: ldap_search
    type: io.kestra.plugin.ldap.Search
    hostname: "{{ vars.hostname }}"
    port: "{{ vars.port }}"
    userDn: "{{ vars.user_dn }}"
    password: "{{ render(vars.password) }}"
    baseDn: "{{ vars.base_dn }}"
    filter: (uid=benjamin.feron)
    attributes:
      - cn
```

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
